### PR TITLE
Temporary workaround for broken hw crypto

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -100,7 +100,7 @@ ifeq ($(HOST_OS),linux)
 endif
 
 # Encryption
-TARGET_HW_DISK_ENCRYPTION := true
+TARGET_HW_DISK_ENCRYPTION := false
 
 # Filesystem
 BOARD_FLASH_BLOCK_SIZE := 131072
@@ -117,7 +117,7 @@ TARGET_USERIMAGES_USE_EXT4 := true
 TARGET_USERIMAGES_USE_F2FS := true
 
 # Workaround for factory issue
-BOARD_VOLD_CRYPTFS_MIGRATE := true
+#BOARD_VOLD_CRYPTFS_MIGRATE := true
 
 # Flags
 COMMON_GLOBAL_CFLAGS += -DNO_SECURE_DISCARD


### PR DESCRIPTION
As of writing, hardware encryption is broken (resulting in "Interrupted, please Reset Phone").

This is a temporary workaround for working software encryption until hw is figured out.

Also, the "Workaround for factory issue" may be completely unnecessary for onyx, as it was a workaround for bacon (OnePlus One) not being able to store the crypto footer properly - thus being migrated on that device to reserve4 - which onyx does not even have (only reserve1 and 2).
